### PR TITLE
Compatibility with all Jetbrains products 2022.3 as well as future releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 ## [Unreleased]
 
+### Support
+
+- Support for Jetbrains' products 2022.3 and future releases
+
 ## [0.0.6]
+
 ### Added
+
 - Enhance File path handling for more flexible Navigation (includes directory path as prefix)
 - Tour's summary on Step's description including the current and the total number of Steps of the Tour
 - Fix potential conflict with existence of files with the same name by prompting a picker dialog to user

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ tasks {
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
+//        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@
 pluginGroup = org.uom.lefterisxris.codetour
 pluginName = CodeTour
 # SemVer format -> https://semver.org
-pluginVersion=0.0.6
+pluginVersion=0.0.7
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=212
-pluginUntilBuild=222.*
+pluginUntilBuild=223.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC


### PR DESCRIPTION
Compatibility with all Jetbrains products 2022.3 as well as future releases
- release: Support for Jetbrains' products 2022.3 and future releases
Signed-off-by: Eleftherios Chrysochoidis <lefterisxris@gmail.com>